### PR TITLE
nixos: allow broadcast/multicast for discovery

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -115,9 +115,28 @@ in
         ProtectHome = true;
         ReadWritePaths = [ cfg.dataDir "/nix/store" ];
         
-        # Network restrictions
+        # Network restrictions: allow LAN ranges plus the link-local
+        # broadcast/multicast addresses peernix uses for peer discovery.
+        # Without these, systemd silently drops:
+        #   * UDP to 255.255.255.255 — the limited-broadcast address
+        #     peernix sends discovery announces to (main.go: updatePeersUDP)
+        #   * UDP to 224.0.0.251 / ff02::fb — the IPv4/IPv6 multicast
+        #     addresses hashicorp/mdns uses (main.go: updatePeersMDNS)
+        # Symptom of the bug: the local peer can respond to *incoming*
+        # discovery (replies go back to 10.0.0.x, which is allowed) but
+        # never proactively announces itself, so remote peers only see
+        # this host if they happen to broadcast first.
         IPAddressDeny = "any";
-        IPAddressAllow = [ "localhost" "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "fe80::/10" ];
+        IPAddressAllow = [
+          "localhost"
+          "10.0.0.0/8"
+          "172.16.0.0/12"
+          "192.168.0.0/16"
+          "fe80::/10"
+          "255.255.255.255"  # IPv4 limited broadcast (peernix UDP discovery)
+          "224.0.0.251"      # IPv4 mDNS multicast
+          "ff02::fb"         # IPv6 mDNS multicast
+        ];
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
         
         # Resource limits


### PR DESCRIPTION
## Summary

- Adds `255.255.255.255`, `224.0.0.251`, and `ff02::fb` to the nixos service's `IPAddressAllow` list so that systemd doesn't silently drop peernix's discovery packets.
- Pure config change; no Go / protocol changes.

## Why this matters

The systemd unit shipped with `IPAddressDeny = "any"` and an `IPAddressAllow` containing only RFC1918 + loopback + IPv6 link-local. Because the limited-broadcast address `255.255.255.255` is *not* inside `10.0.0.0/8`, systemd's BPF address-range filter quietly drops outbound packets there. Same for the IPv4/IPv6 mDNS multicast addresses. The symptom is asymmetric, which is what made it confusing:

- Incoming discovery announces from other peers → unicast reply back to e.g. `10.0.0.43:62016` → **allowed** (destination is inside `10.0.0.0/8`)
- This host's own `updatePeersUDP` broadcasting to `255.255.255.255:9999` → **dropped**, no error visible to peernix

So a NixOS peernix host appears in the peer list of any darwin/macOS peer that broadcast first (and gets unicast pong'd) — but darwin peers that haven't broadcast since the NixOS host came up never see it, because the NixOS host can't announce itself. The bug only manifested when a NixOS box joined an existing darwin-only peernix mesh; mesh-of-darwins worked because launchd has no equivalent address-filter and never blocked anything.

Observed in production with linux-0 (NixOS queue-runner) joining a mesh of 10 darwin builders: `journalctl -u peernix` showed `[DEBUG] Broadcasting enhanced discovery for UDP peer discovery` lines once per `discovery-interval`, but `tcpdump -i eth0 'udp port 9999'` on the same host showed only inbound announces and unicast pongs — never the `*. > 255.255.255.255.9999` broadcast leaving the wire. Adding `255.255.255.255` to `IPAddressAllow` immediately restored bidirectional discovery (verified by watching peer counts on the darwin side go from 10 → 11 within one discovery interval).

The mDNS multicast addresses (`224.0.0.251`, `ff02::fb`) were silently failing for the same reason; on the affected host UDP broadcast alone was sufficient, but they're added here so the second discovery path (`updatePeersMDNS`) also functions as designed.

## Test plan

- [ ] On a NixOS host with this module applied, `sudo journalctl -u peernix | grep Broadcasting` shows entries.
- [ ] `tcpdump -i <iface> 'udp port 9999'` shows outgoing `> 255.255.255.255.9999` packets (one per `discovery-interval`).
- [ ] Other peernix peers (darwin or NixOS) report this host in their `/status` `Discovered Peers` list within one discovery cycle.
- [ ] mDNS path: `tcpdump -i <iface> '(host 224.0.0.251 or host ff02::fb)'` shows outbound peernix mDNS traffic.